### PR TITLE
[fix] npx heapdump-cleanup does not work

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "devDependencies": {
     "eslint": "^6.8.0",
     "prettier": "^1.19.1"
+  },
+  "engines": {
+    "node": ">= 12.7.0"
   }
 }

--- a/src/heapdump-cleanup.js
+++ b/src/heapdump-cleanup.js
@@ -1,7 +1,4 @@
-#!/bin/sh
-":"; //# comment; exec /usr/bin/env node --experimental-modules "$0" "$@"
-// The above hack is documented here: https://web.archive.org/web/20190629142812/http://sambal.org/2014/02/passing-options-node-shebang-line/
-
+#!/usr/bin/env node
 import minimist from "minimist";
 import { parse, stringify } from "./json-stream.js";
 import Snapshot from "./snapshot.js";


### PR DESCRIPTION
The issue is the shell hack used to enable experimental modules
syntax. Apparently the hack is not quite universal, but experimental
modules are enabled by default since 12.7, so removing it in favor of
just introducing Node version requirement.